### PR TITLE
UnicodeMath and UnitsML support sections and blog posts

### DIFF
--- a/_layouts/function.adoc
+++ b/_layouts/function.adoc
@@ -229,8 +229,8 @@ navigation:
       path: /rule
     - title: sum
       path: /sum
-    - title: undercover
-      path: /undercover
+    - title: underover
+      path: /underover
 
   - title: N-ary
     items:

--- a/_layouts/function.adoc
+++ b/_layouts/function.adoc
@@ -35,6 +35,8 @@ navigation:
       path: /boldsansserif
     - title: boldscript
       path: /boldscript
+    - title: cases
+      path: /cases
     - title: cancel
       path: /cancel
     - title: ceil
@@ -65,6 +67,8 @@ navigation:
       path: /doublestruck
     - title: exp
       path: /exp
+    - title: eqarray
+      path: /eqarray
     - title: floor
       path: /floor
     - title: fraktur
@@ -168,6 +172,8 @@ navigation:
 
   - title: Binary
     items:
+    - title: arg
+      path: /arg
     - title: base
       path: /base
     - title: color
@@ -176,12 +182,16 @@ navigation:
       path: /frac
     - title: inf
       path: /inf
+    - title: intent
+      path: /intent
     - title: lim
       path: /lim
     - title: log
       path: /log
     - title: mod
       path: /mod
+    - title: mlabeledtr
+      path: /mlabeledtr
     - title: over
       path: /over
     - title: overset

--- a/_pages/functions.adoc
+++ b/_pages/functions.adoc
@@ -227,8 +227,8 @@ navigation:
       path: /spec/functions/rule
     - title: sum
       path: /spec/functions/sum
-    - title: undercover
-      path: /spec/functions/undercover
+    - title: underover
+      path: /spec/functions/underover
 
   - title: N-ary
     items:
@@ -352,7 +352,7 @@ navigation:
 * link:../functions/prod[prod]
 * link:../functions/rule[rule]
 * link:../functions/sum[sum]
-* link:../functions/undercover[undercover]
+* link:../functions/underover[underover]
 
 == N-ary
 

--- a/_pages/functions.adoc
+++ b/_pages/functions.adoc
@@ -17,6 +17,8 @@ navigation:
       path: /spec/functions/arcsin
     - title: arctan
       path: /spec/functions/arctan
+    - title: arg
+      path: /spec/functions/arg
     - title: array
       path: /spec/functions/array
     - title: bar
@@ -234,6 +236,7 @@ navigation:
 * link:../functions/arccos[arccos]
 * link:../functions/arcsin[arcsin]
 * link:../functions/arctan[arctan]
+* link:../functions/arg[arg]
 * link:../functions/array[array]
 * link:../functions/bar[bar]
 * link:../functions/bmatrix[bmatrix / Bmatrix]

--- a/_pages/functions.adoc
+++ b/_pages/functions.adoc
@@ -17,8 +17,6 @@ navigation:
       path: /spec/functions/arcsin
     - title: arctan
       path: /spec/functions/arctan
-    - title: arg
-      path: /spec/functions/arg
     - title: array
       path: /spec/functions/array
     - title: bar
@@ -35,6 +33,8 @@ navigation:
       path: /spec/functions/boldsansserif
     - title: boldscript
       path: /spec/functions/boldscript
+    - title: cases
+      path: /spec/functions/cases
     - title: cancel
       path: /spec/functions/cancel
     - title: ceil
@@ -65,6 +65,8 @@ navigation:
       path: /spec/functions/doublestruck
     - title: exp
       path: /spec/functions/exp
+    - title: eqarray
+      path: /spec/functions/eqarray
     - title: floor
       path: /spec/functions/floor
     - title: fraktur
@@ -168,6 +170,8 @@ navigation:
 
   - title: Binary
     items:
+    - title: arg
+      path: /spec/functions/arg
     - title: base
       path: /spec/functions/base
     - title: color
@@ -176,12 +180,16 @@ navigation:
       path: /spec/functions/frac
     - title: inf
       path: /spec/functions/inf
+    - title: intent
+      path: /spec/functions/intent
     - title: lim
       path: /spec/functions/lim
     - title: log
       path: /spec/functions/log
     - title: mod
       path: /spec/functions/mod
+    - title: mlabeledtr
+      path: /spec/functions/mlabeledtr
     - title: over
       path: /spec/functions/over
     - title: overset
@@ -236,7 +244,6 @@ navigation:
 * link:../functions/arccos[arccos]
 * link:../functions/arcsin[arcsin]
 * link:../functions/arctan[arctan]
-* link:../functions/arg[arg]
 * link:../functions/array[array]
 * link:../functions/bar[bar]
 * link:../functions/bmatrix[bmatrix / Bmatrix]
@@ -245,6 +252,7 @@ navigation:
 * link:../functions/bolditalic[bolditalic]
 * link:../functions/boldsansserif[boldsansserif]
 * link:../functions/boldscript[boldscript]
+* link:../functions/cases[cases]
 * link:../functions/cancel[cancel]
 * link:../functions/ceil[ceil]
 * link:../functions/cos[cos]
@@ -260,6 +268,7 @@ navigation:
 * link:../functions/dot[dot]
 * link:../functions/doublestruck[doublestruck]
 * link:../functions/exp[exp]
+* link:../functions/eqarray[eqarray]
 * link:../functions/floor[floor]
 * link:../functions/fraktur[fraktur]
 * link:../functions/gcd[gcd]
@@ -313,13 +322,16 @@ navigation:
 
 == Binary
 
+* link:../functions/arg[arg]
 * link:../functions/base[base]
 * link:../functions/color[color]
 * link:../functions/frac[frac]
 * link:../functions/inf[inf]
+* link:../functions/intent[intent]
 * link:../functions/lim[lim]
 * link:../functions/log[log]
 * link:../functions/mod[mod]
+* link:../functions/mlabeledtr[mlabeledtr]
 * link:../functions/over[over]
 * link:../functions/overset[overset]
 * link:../functions/power[power]

--- a/_posts/2023-08-22-using-plurimath.adoc
+++ b/_posts/2023-08-22-using-plurimath.adoc
@@ -29,8 +29,8 @@ excerpt: >-
 
 *Plurimath* is a comprehensive and efficient tool that enhances the way
 mathematical content is converted between different formats. It is designed to
-work with various markup languages such as *MathML*, *LaTeX*, *AsciiMath*, *OMML*, and
-*UnicodeMath* making it a versatile and adaptable tool.
+work with various markup languages such as *MathML*, *LaTeX*, *AsciiMath*, *OMML*,
+*UnicodeMath*, and *UnitsML* making it a versatile and adaptable tool.
 
 One significant advantage is that users don't have to deal with the
 inconvenience of installing and managing multiple libraries for these different
@@ -513,11 +513,29 @@ NOTE: Input can be any of the both mentioned syntaxes, but the output will be in
 
 ==== UnitsML to Formula
 
-There is no direct processing like other languages,
+We can process **UnitsML** using two types of syntaxes.
 
-`Plurimath::Math.parse(string, :<language>) # => NOT SUPPORTED FOR UNITSML`
+The first type of input will be the same syntax followed for the other languages.
 
-The input of **UnitsML** is restricted to a specific syntax inside of an **AsciiMath** string. See the syntax below,
+[source,ruby]
+----
+  string = '"unitsml(<unitsml string>)"' # => anything before after the double quotes will be ignored
+  string = 'unitsml(<unitsml string>)' # => OR anything before letters "unitsml" and after the closing parenthesis will be ignored
+  string = '<unitsml string>' # => OR
+  fomrula = Plurimath::Math.parse(string, :unitsml)
+----
+
+Only the `'<unitsml string>'` part of the string will be processed and the rest will be ignored. see the input examples below
+
+[source,ruby]
+----
+  string = '"unitsml(kg)" 1' # => 1 in this example will be ignored
+  string = '1 "unitsml(kg)"' # => Again, 1 in this example will be ignored
+  formula = Plurimath::Math.parse(string, :unitsml)
+  formula.to_asciimath # => 'rm(kg)'
+----
+
+The other input of **UnitsML** is restricted to a specific syntax inside of an **AsciiMath** string and nothing before or/and after will be ignored. See the syntax below.
 
 [source,ruby]
 ----
@@ -537,3 +555,5 @@ The output syntax will not be the same as the input, see the example below.
 ----
 
 NOTE: In **AsciiMath** strings, **UnitsML** input must be enclosed within double quotes for clarity and specificity.
+
+NOTE: **UnitsML** in output will not be identifiable despite the input syntaxes and/or the output language.

--- a/_posts/2023-08-22-using-plurimath.adoc
+++ b/_posts/2023-08-22-using-plurimath.adoc
@@ -510,3 +510,30 @@ formula.to_unicodemath # >> ∑_(i = 1)^(n) i^(3)
 ----
 
 NOTE: Input can be any of the both mentioned syntaxes, but the output will be in Unicode representation and not in LaTeX alike syntax.
+
+==== UnitsML to Formula
+
+There is no direct processing like other languages,
+
+`Plurimath::Math.parse(string, :<language>) # => NOT SUPPORTED FOR UNITSML`
+
+The input of **UnitsML** is restricted to a specific syntax inside of an **AsciiMath** string. See the syntax below,
+
+[source,ruby]
+----
+  string = '<optional asciimath string>"unitsml(<unitsml string>)"<optional asciimath string>'
+  fomrula = Plurimath::Math.parse(string, :asciimath)
+----
+
+==== Formula to UnitsML
+
+The output syntax will not be the same as the input, see the example below.
+
+[source,ruby]
+----
+  string = '1 "unitsml(kg)"'
+  formula = Plurimath::Math.parse(string, :asciimath)
+  formula.to_asciimath # => '1 rm(kg)'
+----
+
+NOTE: In **AsciiMath** strings, **UnitsML** input must be enclosed within double quotes for clarity and specificity.

--- a/_posts/2023-08-22-using-plurimath.adoc
+++ b/_posts/2023-08-22-using-plurimath.adoc
@@ -29,8 +29,8 @@ excerpt: >-
 
 *Plurimath* is a comprehensive and efficient tool that enhances the way
 mathematical content is converted between different formats. It is designed to
-work with various markup languages such as *MathML*, *LaTeX*, *AsciiMath*, and
-*OMML*, making it a versatile and adaptable tool.
+work with various markup languages such as *MathML*, *LaTeX*, *AsciiMath*, *OMML*, and
+*UnicodeMath* making it a versatile and adaptable tool.
 
 One significant advantage is that users don't have to deal with the
 inconvenience of installing and managing multiple libraries for these different
@@ -463,3 +463,50 @@ This will generate following output of *OMML*
 </m:oMathPara>
 ----
 
+==== UnicodeMath to Formula
+
+Processing the UnicodeMath example below will also follow the same steps.
+
+For UnicodeMath, we have two syntaxes
+
+1. String with Unicode representation
+2. LaTeX alike syntax(for example, \sum, \prod, etc...)
+
+[source,ruby]
+----
+# Unicode representation string
+input_string = '∑_(i=1)^n i^3'
+# OR LaTeX alike syntax
+input_string = '\sum_(i=1)^n i^3'
+formula = Plurimath::Math.parse(input_string, :unicode)
+----
+
+As shown before, the above code will generate following **Formula** object.
+
+[source,ruby]
+----
+Plurimath::Math::Formula.new([
+  Plurimath::Math::Function::Sum.new(
+    Plurimath::Math::Formula.new([
+      Plurimath::Math::Symbol.new("i"),
+      Plurimath::Math::Symbol.new("="),
+      Plurimath::Math::Number.new("1")
+    ]),
+    Plurimath::Math::Symbol.new("n"),
+  ),
+  Plurimath::Math::Function::Power.new(
+    Plurimath::Math::Symbol.new("i"),
+    Plurimath::Math::Number.new("3")
+  )
+])
+----
+
+==== Formula to UnicodeMath
+
+Converting Formula to UnicodeMath will be the same as for the other languages.
+[source,ruby]
+----
+formula.to_unicodemath # >> ∑_(i = 1)^(n) i^(3)
+----
+
+NOTE: Input can be any of both, but the output will be in Unicode representation and not in LaTeX alike syntax.

--- a/_posts/2023-08-22-using-plurimath.adoc
+++ b/_posts/2023-08-22-using-plurimath.adoc
@@ -509,4 +509,4 @@ Converting Formula to UnicodeMath will be the same as for the other languages.
 formula.to_unicodemath # >> ∑_(i = 1)^(n) i^(3)
 ----
 
-NOTE: Input can be any of both, but the output will be in Unicode representation and not in LaTeX alike syntax.
+NOTE: Input can be any of both mentioned syntaxes, but the output will be in Unicode representation and not in LaTeX alike syntax.

--- a/_posts/2023-08-22-using-plurimath.adoc
+++ b/_posts/2023-08-22-using-plurimath.adoc
@@ -465,18 +465,18 @@ This will generate following output of *OMML*
 
 ==== UnicodeMath to Formula
 
-Processing the UnicodeMath example below will also follow the same steps.
+Processing the **UnicodeMath** example below will also follow the same steps.
 
-For UnicodeMath, we have two syntaxes
+For **UnicodeMath**, we have two syntaxes
 
 1. String with Unicode representation
-2. LaTeX alike syntax(for example, \sum, \prod, etc...)
+2. *LaTeX* alike syntax(for example, `\sum`, `\prod`, etc...)
 
 [source,ruby]
 ----
 # Unicode representation string
 input_string = '∑_(i=1)^n i^3'
-# OR LaTeX alike syntax
+# OR **LaTeX** alike syntax
 input_string = '\sum_(i=1)^n i^3'
 formula = Plurimath::Math.parse(input_string, :unicode)
 ----
@@ -503,10 +503,10 @@ Plurimath::Math::Formula.new([
 
 ==== Formula to UnicodeMath
 
-Converting Formula to UnicodeMath will be the same as for the other languages.
+Converting **Formula** to **UnicodeMath** will be the same as for the other languages.
 [source,ruby]
 ----
 formula.to_unicodemath # >> ∑_(i = 1)^(n) i^(3)
 ----
 
-NOTE: Input can be any of both mentioned syntaxes, but the output will be in Unicode representation and not in LaTeX alike syntax.
+NOTE: Input can be any of the both mentioned syntaxes, but the output will be in Unicode representation and not in LaTeX alike syntax.

--- a/_posts/2024-04-05-unicodemath.adoc
+++ b/_posts/2024-04-05-unicodemath.adoc
@@ -1,0 +1,32 @@
+---
+layout: post
+title:  "UnicodeMath in Plurimath"
+date:   2023-08-22 00:00:00 +0800
+categories:
+  - plurimath
+  - using
+authors:
+  -
+    name: Suleman Uzair
+    email: sulemanuzair600@gmail.com
+    social_links:
+      - https://github.com/suleman-uzair/
+  -
+    name: Ronald Tse
+    email: tse@ribose.com
+    use_picture: assets
+    social_links:
+      - https://www.linkedin.com/in/rhtse/
+      - https://github.com/ronaldtse
+excerpt: >-
+  UnicodeMath support in Plurimath.
+---
+
+= UnicodeMath
+
+== Why UnicodeMath?
+
+**Plurimath**, a versatile tool for mathematical representation, has been addressing these challenges by providing conversion capabilities between different markup languages. In a recent development, **Plurimath** has integrated **UnicodeMath** support, further enhancing its capabilities and opening up new possibilities for mathematical expression representation.
+
+**UnicodeMath**, known for its unrestricted support of symbols and scenarios, brings a new level of flexibility to **Plurimath**. With **UnicodeMath** support, users can now express complex mathematical concepts using a wider range of symbols and notations, without being constrained by the limitations of traditional markup languages.
+

--- a/_posts/2024-04-05-unicodemath.adoc
+++ b/_posts/2024-04-05-unicodemath.adoc
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  "UnicodeMath support in Plurimath"
-date:   2023-08-22 00:00:00 +0800
+date:   2024-04-05 00:00:00 +0800
 categories:
   - plurimath
   - using

--- a/_posts/2024-04-05-unicodemath.adoc
+++ b/_posts/2024-04-05-unicodemath.adoc
@@ -1,6 +1,6 @@
 ---
 layout: post
-title:  "UnicodeMath in Plurimath"
+title:  "UnicodeMath support in Plurimath"
 date:   2023-08-22 00:00:00 +0800
 categories:
   - plurimath
@@ -19,14 +19,38 @@ authors:
       - https://www.linkedin.com/in/rhtse/
       - https://github.com/ronaldtse
 excerpt: >-
-  UnicodeMath support in Plurimath.
+  **Plurimath** has long supported **AsciiMath**, **MathML**, **LaTeX**, and **OMML**. Now, it also supports **UnicodeMath**.
 ---
 
 = UnicodeMath
 
-== Why UnicodeMath?
+== Introduction
 
-**Plurimath**, a versatile tool for mathematical representation, has been addressing these challenges by providing conversion capabilities between different markup languages. In a recent development, **Plurimath** has integrated **UnicodeMath** support, further enhancing its capabilities and opening up new possibilities for mathematical expression representation.
+**Plurimath** has been able to handle **AsciiMath**, **MathML**, **LaTeX**, and **OMML** for a while. Now, it's added support for **UnicodeMath**, broadening its range of functionality.
 
-**UnicodeMath**, known for its unrestricted support of symbols and scenarios, brings a new level of flexibility to **Plurimath**. With **UnicodeMath** support, users can now express complex mathematical concepts using a wider range of symbols and notations, without being constrained by the limitations of traditional markup languages.
+== Using UnicodeMath
 
+Input string can be one of any of the following two types
+
+1. Unicode string `# String containing the representation of the symbol`
+2. Name syntax string `# String containing the names instead of the representation.`
+
+Let's start with the Unicode syntax,
+
+[source,ruby]
+----
+string = '∑_(i=1)^n i^3'
+formula = Plurimath::Math.parse(string, :unicode)
+formula.to_unicodemath # => '∑_(i = 1)^(n) i^(3)'
+----
+
+And now the named syntax example.
+
+[source,ruby]
+----
+string = '\sum_(i=1)^n i^3'
+formula = Plurimath::Math.parse(string, :unicode)
+string.to_unicodemath # => '∑_(i = 1)^(n) i^(3)'
+----
+
+NOTE: Input can be any of the both mentioned syntaxes, but the output will be in Unicode representation and not in named syntax.

--- a/_posts/2024-04-09-unitsml.adoc
+++ b/_posts/2024-04-09-unitsml.adoc
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  "UnitsML support in Plurimath"
-date:   2023-08-22 00:00:00 +0800
+date:   2024-04-09 00:00:00 +0800
 categories:
   - plurimath
   - using
@@ -30,11 +30,29 @@ excerpt: >-
 
 == Using UnitsML
 
-There is no direct processing like other languages,
+We can process **UnitsML** using two types of syntaxes.
 
-`Plurimath::Math.parse(string, :<language>) # => NOT SUPPORTED FOR UNITSML`
+The first type of input will be the same syntax followed for the other languages.
 
-The input of **UnitsML** is restricted to a specific syntax inside of an **AsciiMath** string. See the syntax below,
+[source,ruby]
+----
+  string = '"unitsml(<unitsml string>)"' # => anything before after the double quotes will be ignored
+  string = 'unitsml(<unitsml string>)' # => OR anything before letters "unitsml" and after the closing parenthesis will be ignored
+  string = '<unitsml string>' # => OR
+  fomrula = Plurimath::Math.parse(string, :unitsml)
+----
+
+Only the `'<unitsml string>'` part of the string will be processed and the rest will be ignored. see the input examples below
+
+[source,ruby]
+----
+  string = '"unitsml(kg)" 1' # => 1 in this example will be ignored
+  string = '1 "unitsml(kg)"' # => Again, 1 in this example will be ignored
+  formula = Plurimath::Math.parse(string, :unitsml)
+  formula.to_asciimath # => 'rm(kg)'
+----
+
+The other input of **UnitsML** is restricted to a specific syntax inside of an **AsciiMath** string and nothing before or/and after will be ignored. See the syntax below.
 
 [source,ruby]
 ----
@@ -46,9 +64,12 @@ The output syntax will not be the same as the input, see the example below.
 
 [source,ruby]
 ----
-  string = '1 "unitsml(kg)"'
+  string = '"unitsml(kg)" 1' # => 1 will not be ignored
+  string = '1 "unitsml(kg)"' # => Again, 1 will not be ignored
   formula = Plurimath::Math.parse(string, :asciimath)
   formula.to_asciimath # => '1 rm(kg)'
 ----
 
 NOTE: In **AsciiMath** strings, **UnitsML** input must be enclosed within double quotes for clarity and specificity.
+
+NOTE: **UnitsML** in output will not be identifiable despite the input syntaxes and/or the output language.

--- a/_posts/2024-04-09-unitsml.adoc
+++ b/_posts/2024-04-09-unitsml.adoc
@@ -1,0 +1,54 @@
+---
+layout: post
+title:  "UnitsML support in Plurimath"
+date:   2023-08-22 00:00:00 +0800
+categories:
+  - plurimath
+  - using
+authors:
+  -
+    name: Suleman Uzair
+    email: sulemanuzair600@gmail.com
+    social_links:
+      - https://github.com/suleman-uzair/
+  -
+    name: Ronald Tse
+    email: tse@ribose.com
+    use_picture: assets
+    social_links:
+      - https://www.linkedin.com/in/rhtse/
+      - https://github.com/ronaldtse
+excerpt: >-
+  Easily parse scientific units of measure with the recently added support of **UnitsML** in **Plurimath**.
+---
+
+= UnitsML
+
+== Introduction
+
+**Plurimath** has recently integrated **UnitsML**, empowering users with enhanced capabilities to process scientific units of measurement. This enhancement reflects **Plurimath**'s commitment to adapting to the evolving needs of users in mathematics and science.
+
+== Using UnitsML
+
+There is no direct processing like other languages,
+
+`Plurimath::Math.parse(string, :<language>) # => NOT SUPPORTED FOR UNITSML`
+
+The input of **UnitsML** is restricted to a specific syntax inside of an **AsciiMath** string. See the syntax below,
+
+[source,ruby]
+----
+  string = '<optional asciimath string>"unitsml(<unitsml string>)"<optional asciimath string>'
+  fomrula = Plurimath::Math.parse(string, :asciimath)
+----
+
+The output syntax will not be the same as the input, see the example below.
+
+[source,ruby]
+----
+  string = '1 "unitsml(kg)"'
+  formula = Plurimath::Math.parse(string, :asciimath)
+  formula.to_asciimath # => '1 rm(kg)'
+----
+
+NOTE: In **AsciiMath** strings, **UnitsML** input must be enclosed within double quotes for clarity and specificity.

--- a/functions/abs.adoc
+++ b/functions/abs.adoc
@@ -66,3 +66,10 @@ abs(x)
 </m:oMathPara>
 ----
 
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+⒜(x)
+----

--- a/functions/arccos.adoc
+++ b/functions/arccos.adoc
@@ -89,3 +89,11 @@ arccos(x)
   </m:oMath>
 </m:oMathPara>
 ----
+
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+arccos(x)
+----

--- a/functions/arcsin.adoc
+++ b/functions/arcsin.adoc
@@ -89,3 +89,11 @@ arcsin(x)
   </m:oMath>
 </m:oMathPara>
 ----
+
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+arcsin(x)
+----

--- a/functions/arctan.adoc
+++ b/functions/arctan.adoc
@@ -90,3 +90,10 @@ arctan(x)
 </m:oMathPara>
 ----
 
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+arctan(x)
+----

--- a/functions/arg.adoc
+++ b/functions/arg.adoc
@@ -1,0 +1,27 @@
+---
+title: "`arg` (binary)"
+layout: function
+function-name: arg
+function-type: binary
+---
+
+[[arg]]
+== arg
+
+=== MathML
+
+[source,xml]
+----
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+  <mstyle displaystyle="true">
+    <mi arg="d">&#x1d451;</mi>
+  </mstyle>
+</math>
+----
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+ⓐ(d 𝑑)
+----

--- a/functions/base.adoc
+++ b/functions/base.adoc
@@ -73,3 +73,11 @@ x_{y}
 </m:oMathPara>
 ----
 
+
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+x_(y)
+----

--- a/functions/bmatrix.adoc
+++ b/functions/bmatrix.adoc
@@ -16,6 +16,14 @@ function-type: unary
 ----
 
 
+=== UnicodeMath
+
+[source,unicodemath]
+----
+ⓢ(x@y@z)
+----
+
+
 NOTE: In other conversions, the generated output will resemble the content in the link:../table[Table class]
 
 [[Bmatrix]]
@@ -26,6 +34,14 @@ NOTE: In other conversions, the generated output will resemble the content in th
 [source,latex]
 ----
 \begin{Bmatrix}x \\ y \\ z\end{Bmatrix}
+----
+
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+Ⓢ(x@y@z)
 ----
 
 

--- a/functions/bold.adoc
+++ b/functions/bold.adoc
@@ -54,3 +54,10 @@ bb(x)
 </m:oMathPara>
 ----
 
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+\mbfd
+----

--- a/functions/boldfraktur.adoc
+++ b/functions/boldfraktur.adoc
@@ -40,4 +40,12 @@ function-type: unary
 ----
 
 
+=== UnicodeMath
+
+[source,unicodemath]
+----
+\mbffrakx
+----
+
+
 NOTE: In other conversions, the value of the class will be processed as a simple text. For example, the output of this example in *AsciiMath* will be represented as `x`.

--- a/functions/bolditalic.adoc
+++ b/functions/bolditalic.adoc
@@ -39,4 +39,12 @@ function-type: unary
 ----
 
 
+=== UnicodeMath
+
+[source,unicodemath]
+----
+\mbfitx
+----
+
+
 NOTE: In other conversions, the value of the class will be processed as a straightforward equation. For example, the output of this example in *AsciiMath* will be represented as `x`.

--- a/functions/boldsansserif.adoc
+++ b/functions/boldsansserif.adoc
@@ -40,4 +40,12 @@ function-type: unary
 ----
 
 
+=== UnicodeMath
+
+[source,unicodemath]
+----
+\mbfsansx
+----
+
+
 NOTE: In other conversions, the value of the class will be processed as a straightforward equation. For example, the output of this example in *AsciiMath* will be represented as `x`.

--- a/functions/boldscript.adoc
+++ b/functions/boldscript.adoc
@@ -40,4 +40,12 @@ function-type: unary
 ----
 
 
+=== UnicodeMath
+
+[source,unicodemath]
+----
+\mbfscrx
+----
+
+
 NOTE: In other conversions, the value of the class will be processed as a straightforward equation. For example, the output of this example in *AsciiMath* will be represented as `x`.

--- a/functions/cases.adoc
+++ b/functions/cases.adoc
@@ -1,0 +1,18 @@
+---
+title: "`cases` (unary)"
+layout: function
+function-name: cases
+function-type: unary
+---
+
+[[cases]]
+== cases
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+Ⓒ(1&2@3&4)
+----
+
+NOTE: In other conversions, the generated output will resemble the content in the link:../table[Table class]

--- a/functions/color.adoc
+++ b/functions/color.adoc
@@ -41,4 +41,13 @@ color(red)(y)
 ----
 
 
+=== UnicodeMath
+
+[source,unicodemath]
+----
+✎(red&x)
+----
+
+
+
 NOTE: In other conversions, the value of the class will be processed as a simple text. For example, the output of this example in *AsciiMath* will be represented as `x`.

--- a/functions/cos.adoc
+++ b/functions/cos.adoc
@@ -89,3 +89,11 @@ cos(x)
   </m:oMath>
 </m:oMathPara>
 ----
+
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+cos⁡(x)
+----

--- a/functions/cosh.adoc
+++ b/functions/cosh.adoc
@@ -90,3 +90,10 @@ cosh(x)
 </m:oMathPara>
 ----
 
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+cos⁡h(x)
+----

--- a/functions/cot.adoc
+++ b/functions/cot.adoc
@@ -89,3 +89,12 @@ cot(x)
   </m:oMath>
 </m:oMathPara>
 ----
+
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+cost(x)
+----
+

--- a/functions/coth.adoc
+++ b/functions/coth.adoc
@@ -89,3 +89,12 @@ coth(x)
   </m:oMath>
 </m:oMathPara>
 ----
+
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+coth(x)
+----
+

--- a/functions/csc.adoc
+++ b/functions/csc.adoc
@@ -89,3 +89,11 @@ csc(x)
   </m:oMath>
 </m:oMathPara>
 ----
+
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+csc(x)
+----

--- a/functions/csch.adoc
+++ b/functions/csch.adoc
@@ -89,3 +89,11 @@ csch(x)
   </m:oMath>
 </m:oMathPara>
 ----
+
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+csch(x)
+----

--- a/functions/deg.adoc
+++ b/functions/deg.adoc
@@ -16,4 +16,12 @@ function-type: unary
 ----
 
 
+=== UnicodeMath
+
+[source,unicodemath]
+----
+deg⁡(x)
+----
+
+
 NOTE: In other conversions, the value of the class will be processed as a simple text. For example, the input of this example in *AsciiMath* will be processed as `d e g \(x\)`.

--- a/functions/det.adoc
+++ b/functions/det.adoc
@@ -43,4 +43,12 @@ det(x)
 ----
 
 
+=== UnicodeMath
+
+[source,unicodemath]
+----
+det⁡(x)
+----
+
+
 NOTE: In other conversions, the value of the class will be processed as a simple text. For example, the *presentation* of this example in *OMML*  will be `det ("x")`.

--- a/functions/dim.adoc
+++ b/functions/dim.adoc
@@ -24,4 +24,12 @@ dim(x)
 ----
 
 
+=== UnicodeMath
+
+[source,unicodemath]
+----
+dim⁡(x)
+----
+
+
 NOTE: In other conversions, the value of the class will be processed as a simple text. For example, the *presentation* of this example in *OMML* will be represented as `dim (x)`.

--- a/functions/doublestruck.adoc
+++ b/functions/doublestruck.adoc
@@ -53,3 +53,11 @@ mathbb(x)
   </m:oMath>
 </m:oMathPara>
 ----
+
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+\Bbbx
+----

--- a/functions/eqarray.adoc
+++ b/functions/eqarray.adoc
@@ -1,0 +1,18 @@
+---
+title: "`eqarray` (unary)"
+layout: function
+function-name: eqarray
+function-type: unary
+---
+
+[[eqarray]]
+== eqarray
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+█(1&2@3&4)
+----
+
+NOTE: In other conversions, the generated output will resemble the content in the link:../table[Table class]

--- a/functions/exp.adoc
+++ b/functions/exp.adoc
@@ -43,4 +43,12 @@ exp(x)
 ----
 
 
+=== UnicodeMath
+
+[source,unicodemath]
+----
+exp⁡(x)
+----
+
+
 NOTE: In other conversions, the value of the class will be processed as a simple text. For example, the presentation of this example in *OMML* will be represented as `exp ("x")`.

--- a/functions/fenced.adoc
+++ b/functions/fenced.adoc
@@ -67,3 +67,10 @@ function-type: ternary
 </m:oMathPara>
 ----
 
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+(x)
+----

--- a/functions/frac.adoc
+++ b/functions/frac.adoc
@@ -68,3 +68,11 @@ frac(x)(y)
   </m:oMath>
 </m:oMathPara>
 ----
+
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+(x)/(y)
+----

--- a/functions/fraktur.adoc
+++ b/functions/fraktur.adoc
@@ -54,3 +54,11 @@ mathfrak(x)
   </m:oMath>
 </m:oMathPara>
 ----
+
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+\mfrakx
+----

--- a/functions/gcd.adoc
+++ b/functions/gcd.adoc
@@ -43,4 +43,12 @@ gcd(x)
 ----
 
 
+=== UnicodeMath
+
+[source,unicodemath]
+----
+gcd(x)
+----
+
+
 NOTE: In other conversions, the value of the class will be processed as a simple text. For example, the presentation of this example in *OMML* will be represented as `gcd ("x")`.

--- a/functions/hom.adoc
+++ b/functions/hom.adoc
@@ -16,4 +16,12 @@ function-type: unary
 ----
 
 
+=== UnicodeMath
+
+[source,unicodemath]
+----
+hom(x)
+----
+
+
 NOTE: In other conversions, the value of the class will be processed as a simple text. For example, the output of this example in *AsciiMath* will be represented as `hom (x)`.

--- a/functions/inf.adoc
+++ b/functions/inf.adoc
@@ -23,4 +23,12 @@ inf_(x)^(y)
 ----
 
 
+=== UnicodeMath
+
+[source,unicodemath]
+----
+inf(x)
+----
+
+
 NOTE: In other conversions, the generated output will resemble the content in the link:../underover[underover class]

--- a/functions/int.adoc
+++ b/functions/int.adoc
@@ -75,3 +75,11 @@ int_(x)^(y) z
   </m:oMath>
 </m:oMathPara>
 ----
+
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+∫_(x)^(y)▒〖z〗
+----

--- a/functions/intent.adoc
+++ b/functions/intent.adoc
@@ -1,16 +1,16 @@
 ---
-title: "`arg` (binary)"
+title: "`intent` (binary)"
 layout: function
-function-name: arg
+function-name: intent
 function-type: binary
 ---
 
-[[arg]]
-== arg
+[[intent]]
+== intent
 
 === UnicodeMath
 
 [source,unicodemath]
 ----
-ⓐ(d 𝑑)
+ⓘ("d" 𝑑)
 ----

--- a/functions/italic.adoc
+++ b/functions/italic.adoc
@@ -53,3 +53,11 @@ ii(x)
   </m:oMath>
 </m:oMathPara>
 ----
+
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+\mitx
+----

--- a/functions/ker.adoc
+++ b/functions/ker.adoc
@@ -16,4 +16,12 @@ function-type: unary
 ----
 
 
+=== UnicodeMath
+
+[source,unicodemath]
+----
+ker(x)
+----
+
+
 NOTE: In other conversions, the value of the class will be processed as a simple text. For example, the output of this example in *AsciiMath* will be represented as `ker(x)`.

--- a/functions/ln.adoc
+++ b/functions/ln.adoc
@@ -43,4 +43,12 @@ ln(x)
 ----
 
 
+=== UnicodeMath
+
+[source,unicodemath]
+----
+ln(x)
+----
+
+
 NOTE: In other conversions, the value of the class will be processed as a simple text. For example, the presentation of this example in *OMML* will be represented as `ln ("x")`.

--- a/functions/log.adoc
+++ b/functions/log.adoc
@@ -77,3 +77,11 @@ log_(x)^(y)
   </m:oMath>
 </m:oMathPara>
 ----
+
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+log(x)
+----

--- a/functions/matrix.adoc
+++ b/functions/matrix.adoc
@@ -16,4 +16,12 @@ function-type: unary
 ----
 
 
+=== UnicodeMath
+
+[source,unicodemath]
+----
+■(x&y)
+----
+
+
 NOTE: In other conversions, the generated output will resemble the content in the link:../table[Table class]

--- a/functions/max.adoc
+++ b/functions/max.adoc
@@ -43,4 +43,12 @@ max(x)
 ----
 
 
+=== UnicodeMath
+
+[source,unicodemath]
+----
+max(x)
+----
+
+
 NOTE: In other conversions, the value of the class will be processed as a simple text. For example, the *presentation* of this example in *OMML*  will be `max ("x")`.

--- a/functions/min.adoc
+++ b/functions/min.adoc
@@ -43,5 +43,12 @@ min(x)
 ----
 
 
-NOTE: In other conversions, the value of the class will be processed as a simple text. For example, the *presentation* of this example in *OMML*  will be `min ("x")`.
+=== UnicodeMath
 
+[source,unicodemath]
+----
+min(x)
+----
+
+
+NOTE: In other conversions, the value of the class will be processed as a simple text. For example, the *presentation* of this example in *OMML*  will be `min ("x")`.

--- a/functions/mlabeledtr.adoc
+++ b/functions/mlabeledtr.adoc
@@ -1,16 +1,16 @@
 ---
-title: "`arg` (binary)"
+title: "`mlabeledtr` (binary)"
 layout: function
-function-name: arg
+function-name: mlabeledtr
 function-type: binary
 ---
 
-[[arg]]
-== arg
+[[mlabeledtr]]
+== mlabeledtr
 
 === UnicodeMath
 
 [source,unicodemath]
 ----
-ⓐ(d 𝑑)
+𝑑 #[2]
 ----

--- a/functions/mod.adoc
+++ b/functions/mod.adoc
@@ -40,4 +40,12 @@ x mod y
 ----
 
 
+=== UnicodeMath
+
+[source,unicodemath]
+----
+mod(x)
+----
+
+
 NOTE: In other conversions, the value of the class will be processed as a simple text. For example, the *presentation* of this example in *OMML*  will be `"x" rm( mod ) "y"`.

--- a/functions/monospace.adoc
+++ b/functions/monospace.adoc
@@ -53,3 +53,11 @@ mathtt(x)
   </m:oMath>
 </m:oMathPara>
 ----
+
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+ￗ(x)
+----

--- a/functions/normal.adoc
+++ b/functions/normal.adoc
@@ -1,3 +1,4 @@
+
 ---
 title: "`normal` (unary)"
 layout: function
@@ -54,3 +55,10 @@ rm(x)
 </m:oMathPara>
 ----
 
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+\mupx
+----

--- a/functions/oint.adoc
+++ b/functions/oint.adoc
@@ -75,3 +75,11 @@ oint_(x)^(y) z
   </m:oMath>
 </m:oMathPara>
 ----
+
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+∮_(d)^(x)▒〖e〗
+----

--- a/functions/overset.adoc
+++ b/functions/overset.adoc
@@ -68,3 +68,11 @@ overset(x)(y)
   </m:oMath>
 </m:oMathPara>
 ----
+
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+(x)┴(y)
+----

--- a/functions/phantom.adoc
+++ b/functions/phantom.adoc
@@ -51,5 +51,12 @@ function-type: unary
 ----
 
 
-NOTE: In AsciiMath conversion, it will add `\ ` replacing all the letters as value of the object. For example, the output of this example in *AsciiMath* will be `\ `.
+=== UnicodeMath
 
+[source,unicodemath]
+----
+⟡(x)
+----
+
+
+NOTE: In AsciiMath conversion, it will add `\ ` replacing all the letters as value of the object. For example, the output of this example in *AsciiMath* will be `\ `.

--- a/functions/pmatrix.adoc
+++ b/functions/pmatrix.adoc
@@ -16,5 +16,12 @@ function-type: unary
 ----
 
 
-NOTE: In other conversions, the generated output will resemble the content in the link:../table[Table class]
+=== UnicodeMath
 
+[source,unicodemath]
+----
+⒨(𝑥&𝑦&𝑧)
+----
+
+
+NOTE: In other conversions, the generated output will resemble the content in the link:../table[Table class]

--- a/functions/power.adoc
+++ b/functions/power.adoc
@@ -69,3 +69,10 @@ x^{y}
 </m:oMathPara>
 ----
 
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+x^(y)
+----

--- a/functions/powerbase.adoc
+++ b/functions/powerbase.adoc
@@ -75,3 +75,10 @@ x_{y}^{z}
 </m:oMathPara>
 ----
 
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+x_(y)^(z)
+----

--- a/functions/prod.adoc
+++ b/functions/prod.adoc
@@ -76,3 +76,10 @@ prod_(x)^(y) z
 </m:oMathPara>
 ----
 
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+∏_(x)^(y)▒〖z〗
+----

--- a/functions/root.adoc
+++ b/functions/root.adoc
@@ -68,3 +68,11 @@ root(x)(y)
   </m:oMath>
 </m:oMathPara>
 ----
+
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+√(x&y)
+----

--- a/functions/sansserif.adoc
+++ b/functions/sansserif.adoc
@@ -56,3 +56,9 @@ mathsf(x)
 ----
 
 
+=== UnicodeMath
+
+[source,unicodemath]
+----
+\msans(x)
+----

--- a/functions/sansserifbolditalic.adoc
+++ b/functions/sansserifbolditalic.adoc
@@ -40,5 +40,11 @@ function-type: unary
 ----
 
 
-NOTE: In other conversions, the value of the class will be processed as a simple text. For example, the output of this example in *AsciiMath* will be represented as `x`.
+=== UnicodeMath
 
+[source,unicodemath]
+----
+\mbfitsans(x)
+----
+
+NOTE: In other conversions, the value of the class will be processed as a simple text. For example, the output of this example in *AsciiMath* will be represented as `x`.

--- a/functions/sansserifitalic.adoc
+++ b/functions/sansserifitalic.adoc
@@ -40,5 +40,12 @@ function-type: unary
 ----
 
 
-NOTE: In other conversions, the value of the class will be processed as a simple text. For example, the output of this example in *AsciiMath* will be represented as `x`.
+=== UnicodeMath
 
+[source,unicodemath]
+----
+\mitsans(x)
+----
+
+
+NOTE: In other conversions, the value of the class will be processed as a simple text. For example, the output of this example in *AsciiMath* will be represented as `x`.

--- a/functions/script.adoc
+++ b/functions/script.adoc
@@ -55,3 +55,10 @@ mathcal(x)
 </m:oMathPara>
 ----
 
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+\mscrx
+----

--- a/functions/sec.adoc
+++ b/functions/sec.adoc
@@ -90,3 +90,10 @@ sec(x)
 </m:oMathPara>
 ----
 
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+sec(x)
+----

--- a/functions/sech.adoc
+++ b/functions/sech.adoc
@@ -91,3 +91,9 @@ sech(x)
 ----
 
 
+=== UnicodeMath
+
+[source,unicodemath]
+----
+sech(x)
+----

--- a/functions/sin.adoc
+++ b/functions/sin.adoc
@@ -90,3 +90,10 @@ sin(x)
 </m:oMathPara>
 ----
 
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+sin(x)
+----

--- a/functions/sinh.adoc
+++ b/functions/sinh.adoc
@@ -90,3 +90,10 @@ sinh(x)
 </m:oMathPara>
 ----
 
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+sinh(x)
+----

--- a/functions/sqrt.adoc
+++ b/functions/sqrt.adoc
@@ -65,3 +65,12 @@ sqrt(x)
 </m:oMathPara>
 ----
 
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+sqrt(x)
+----
+
+

--- a/functions/sum.adoc
+++ b/functions/sum.adoc
@@ -76,3 +76,10 @@ sum_(x)^(y) z
 </m:oMathPara>
 ----
 
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+∑_(x)^(y)▒〖z〗
+----

--- a/functions/table.adoc
+++ b/functions/table.adoc
@@ -93,3 +93,10 @@ function-type: unary
 </m:oMathPara>
 ----
 
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+■(𝑥&𝑦&𝑧)
+----

--- a/functions/tan.adoc
+++ b/functions/tan.adoc
@@ -90,3 +90,10 @@ tan(x)
 </m:oMathPara>
 ----
 
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+tan(x)
+----

--- a/functions/tanh.adoc
+++ b/functions/tanh.adoc
@@ -90,3 +90,10 @@ tanh(x)
 </m:oMathPara>
 ----
 
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+tanh(x)
+----

--- a/functions/text.adoc
+++ b/functions/text.adoc
@@ -50,3 +50,9 @@ function-type: unary
 ----
 
 
+=== UnicodeMath
+
+[source,unicodemath]
+----
+"x"
+----

--- a/functions/underover.adoc
+++ b/functions/underover.adoc
@@ -72,4 +72,12 @@ function-type: ternary
 ----
 
 
+=== UnicodeMath
+
+[source,unicodemath]
+----
+x┬(z)┴(y)
+----
+
+
 NOTE: In other conversions, the generated output will resemble the content in the link:../powerbase[PowerBase class]

--- a/functions/underset.adoc
+++ b/functions/underset.adoc
@@ -68,3 +68,11 @@ underset(x)(y)
   </m:oMath>
 </m:oMathPara>
 ----
+
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+(x)┬y
+----

--- a/functions/vmatrix.adoc
+++ b/functions/vmatrix.adoc
@@ -16,6 +16,14 @@ function-type: unary
 ----
 
 
+=== UnicodeMath
+
+[source,unicodemath]
+----
+⒱(x&y&z)
+----
+
+
 
 [[Vmatrix]]
 == Vmatrix
@@ -25,6 +33,14 @@ function-type: unary
 [source,latex]
 ----
 \begin{Vmatrix}x \\ y \\ z\end{Vmatrix}
+----
+
+
+=== UnicodeMath
+
+[source,unicodemath]
+----
+⒩(x&y&z)
 ----
 
 


### PR DESCRIPTION
This PR adds **UnicodeMath** and **UnitsML** conversion section with examples in **Using Plurimath** blog post.
Adds newly added function classes in **Plurimath**.
Adds new blog posts announcing new features availability.

closes #29 
closes #31 